### PR TITLE
FORK: Fix jspecify missing lib

### DIFF
--- a/app-samples/gradle/libs.versions.toml
+++ b/app-samples/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ androidx-core = "1.13.1"
 androidx-car = "1.7.0-beta01"
 androidx-constraintlayout = "2.1.4"
 core-ktx = "1.13.1"
+jspecify = "1.0.0"
 
 [libraries]
 androidx-car-app = { module = "androidx.car.app:app", version.ref = "androidx-car" }
@@ -18,6 +19,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-core = { module = "androidx.core:core", version.ref = "androidx-core" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 
 
 [plugins]

--- a/app-samples/showcase/automotive/build.gradle
+++ b/app-samples/showcase/automotive/build.gradle
@@ -58,4 +58,5 @@ dependencies {
     implementation libs.androidx.app.automotive
     implementation project(":showcase:common")
     implementation libs.androidx.core.ktx
+    api libs.jspecify
 }

--- a/app-samples/showcase/common/build.gradle
+++ b/app-samples/showcase/common/build.gradle
@@ -45,4 +45,5 @@ dependencies {
     implementation(libs.androidx.car.app)
     implementation libs.androidx.annotation.experimental
     implementation libs.androidx.core.ktx
+    api libs.jspecify
 }

--- a/app-samples/showcase/mobile/build.gradle
+++ b/app-samples/showcase/mobile/build.gradle
@@ -58,4 +58,5 @@ dependencies {
     implementation libs.androidx.app.projected
     implementation project(":showcase:common")
     implementation libs.androidx.core.ktx
+    api libs.jspecify
 }


### PR DESCRIPTION
With this [commit](https://android.googlesource.com/platform/frameworks/support/+/5e58d14517d8a358b585727db0dbb4624120eef1) Google broke the build for the Github version.

This PR includes the missing jspecify dependency, which seems to be included by the AndroidX plugin internally.